### PR TITLE
refactor!: Make headers property readonly

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -17,7 +17,7 @@ class Response {
          * @name Response#meta
          */
         this.meta = { statusCode: 200 };
-        Object.defineProperty(this.meta, 'headers', { value: {}, writable: true });
+        Object.defineProperty(this.meta, 'headers', { value: {}, writable: false });
 
         /**
          * Error info (null on success)

--- a/test/response.spec.js
+++ b/test/response.spec.js
@@ -24,13 +24,12 @@ describe('Response', () => {
         expect(response.meta.headers).to.be.an('object');
     });
 
-    it('should have writeable meta.headers property', () => {
+    it('should disallow setting meta.headers property directly', () => {
         const response = new Response(new Request(reqOpts));
 
         expect(() => {
             response.meta.headers = { 'Content-Type': 'application/pdf' };
-        }).to.not.throw(Error);
-        expect(response.meta.headers).to.have.property('Content-Type');
+        }).to.throw(TypeError, `Cannot assign to read only property 'headers'`);
     });
 
     it('should not expose headers in response.meta', () => {


### PR DESCRIPTION
BREAKING CHANGE: response.meta.headers cannot be overwritten anymore.
Use response.header() method to set single header.

Instead of
```js
response.meta.headers = { 'content-type': 'text/html', 'x-foo': 'bar' };
```
do
```js
response.header('content-type', 'text/html');
response.header('x-foo', 'bar');
```