### PR TITLE
Pass through request._auth on api.execute

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -214,7 +214,7 @@ class Api extends PromiseEventEmitter {
             if (err.httpStatusCode && err.httpStatusCode < 500) {
                 this.log.info(
                     { err, req: request._httpRequest },
-                    `Request error (${request.resource}/${request.id || ''}.${request.format}?do=${request.action})`
+                    `Request error (${request.resource}/${request.id || ''}.${request.format}?action=${request.action})`
                 );
             } else {
                 this.log.error({ err, req: request._httpRequest }, 'Server error');

--- a/lib/request.js
+++ b/lib/request.js
@@ -100,7 +100,7 @@ class Request {
          * @name Request#_auth
          * @readonly
          */
-        writable('_auth', null);
+        writable('_auth', options._auth || null);
 
         /**
          * HTTP request object (if available)

--- a/lib/url-parser.js
+++ b/lib/url-parser.js
@@ -30,6 +30,7 @@ function httpToFloraRequest(httpRequest, { postTimeout } = {}) {
          */
         const opts = {
             resource: matches[1],
+            _auth: null,
             _status: httpRequest.flora.status,
             _httpRequest: httpRequest
         };

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -288,6 +288,40 @@ describe('Api', () => {
                 done();
             });
         });
+
+        it('should clone the Request', async () => {
+            const api = new Api();
+            await api.init({
+                log,
+                resourcesPath: path.join(__dirname, 'fixtures', 'extensions', 'resources'),
+                dataSources: {
+                    empty: {
+                        constructor: testDataSource
+                    }
+                }
+            });
+
+            const r = new Request({ resource: 'simple-js' });
+            const { request } = await api.execute(r);
+            expect(r).to.not.equal(request);
+        });
+
+        it('should pass through _auth property', async () => {
+            const api = new Api();
+            await api.init({
+                log,
+                resourcesPath: path.join(__dirname, 'fixtures', 'extensions', 'resources'),
+                dataSources: {
+                    empty: {
+                        constructor: testDataSource
+                    }
+                }
+            });
+
+            const r = new Request({ resource: 'simple-js', _auth: 'AUTH' });
+            const { request } = await api.execute(r);
+            expect(request._auth).to.equal('AUTH');
+        });
     });
 
     describe('formats', () => {

--- a/test/url-parser.spec.js
+++ b/test/url-parser.spec.js
@@ -233,5 +233,42 @@ describe('HTTP request parsing', () => {
                     done();
                 });
         });
+
+        it('should remove protected properties (GET)', (done) => {
+            httpRequest.url = 'http://api.example.com/user/1337.jpg?_auth=FOO';
+            parseRequest(httpRequest)
+                .then((request) => {
+                    expect(request._auth).to.equal(null);
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should remove protected properties (urlencoded)', (done) => {
+            httpRequest.url = 'http://api.example.com/user/';
+            httpRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
+            httpRequest.payload = '_auth=FOO';
+            httpRequest.method = 'POST';
+            httpRequest.headers['content-length'] = httpRequest.payload.length;
+            parseRequest(httpRequest)
+                .then((request) => {
+                    expect(request._auth).to.equal(null);
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should remove protected properties (JSON)', (done) => {
+            httpRequest.url = 'http://api.example.com/user/';
+            httpRequest.payload = '{"_auth": "FOO"}';
+            httpRequest.method = 'POST';
+            httpRequest.headers['content-length'] = httpRequest.payload.length;
+            parseRequest(httpRequest)
+                .then((request) => {
+                    expect(request._auth).to.equal(null);
+                    done();
+                })
+                .catch(done);
+        });
     });
 });


### PR DESCRIPTION
Currently it is not possible to pass an existing `_auth` instance to `api.execute()`:

```js
await api.execute(
    new Request({
        resource: 'my-ressource',
        id: 42,
        _auth: existingAuthData, // is ignored
    })
);
```

This PR enables auth data to be passed through to the Request constructor, and thus also to `api.execute()` (which does `new Request(request)`).

The URL parser is updated to explicitly ignore the _auth parameters in the HTTP request payload, so it is still not possible to inject resolved authentication data by using something like `https://api.example.com/resource/1?_auth=FOO`.