### PR TITLE
fix: fix TypeError when handling external errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -208,11 +208,15 @@ class Server {
     _sendError(err, httpRequest, httpResponse) {
         const response = new Response();
 
-        if (err.data) response.data = err.data;
-        if (err.meta) Object.assign(response.meta, err.meta);
-        response.meta.statusCode = err.httpStatusCode || new errors.FloraError().httpStatusCode;
-        response.error = errors.format(err, { exposeErrors: this.api.config.exposeErrors });
+        if (err instanceof errors.FloraError) {
+            if (err.data) response.data = err.data;
+            if (err.meta) Object.assign(response.meta, err.meta);
+            response.meta.statusCode = err.httpStatusCode || new errors.FloraError().httpStatusCode;
+        } else {
+            response.meta.statusCode = 500;
+        }
 
+        response.error = errors.format(err, { exposeErrors: this.api.config.exposeErrors });
         this._sendResponse(response, httpRequest, httpResponse);
     }
 


### PR DESCRIPTION
When an error is handled which is not a FloraError, its properties are copied to the response object. This might be a problem, e.g. when there is a meta.headers property (which is protected in FloraErrors) and might cause a TypeError.