### PR TITLE
Error headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -212,8 +212,8 @@ class Server {
             if (err.data) response.data = err.data;
             if (err.meta && typeof err.meta === 'object') {
                 if (typeof err.meta.headers === 'object') {
-                    for (let header in err.meta.headers) {
-                        response.meta.headers[header] = err.meta.headers[header];
+                    for (let [header, value] of Object.entries(err.meta.headers || {})) {
+                        response.header(header, value);
                     }
                 }
                 for (let key in err.meta) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -210,7 +210,7 @@ class Server {
 
         if (err instanceof errors.FloraError) {
             if (err.data) response.data = err.data;
-            if (err.meta) Object.assign(response.meta, err.meta);
+            if (err.meta && err.meta.headers) Object.assign(response.meta.headers, err.meta.headers);
             response.meta.statusCode = err.httpStatusCode || new errors.FloraError().httpStatusCode;
         } else {
             response.meta.statusCode = 500;

--- a/lib/server.js
+++ b/lib/server.js
@@ -210,7 +210,16 @@ class Server {
 
         if (err instanceof errors.FloraError) {
             if (err.data) response.data = err.data;
-            if (err.meta && err.meta.headers) Object.assign(response.meta.headers, err.meta.headers);
+            if (err.meta && typeof err.meta === 'object') {
+                if (typeof err.meta.headers === 'object') {
+                    for (let header in err.meta.headers) {
+                        response.meta.headers[header] = err.meta.headers[header];
+                    }
+                }
+                for (let key in err.meta) {
+                    if (key !== 'headers') response.meta[key] = err.meta[key];
+                }
+            }
             response.meta.statusCode = err.httpStatusCode || new errors.FloraError().httpStatusCode;
         } else {
             response.meta.statusCode = 500;


### PR DESCRIPTION
Currently it is not possible to add HTTP headers to an error response.
This should be possible:

```js
const err = new RequestError('Foo');
err.meta = { headers: { foo': 'bar' } };
throw err;
```

`err.meta` is being assigned to `response.meta` [here](https://github.com/florajs/flora/blob/v6.0.1/lib/server.js#L213), but this always fails because the `headers` property is not writable, causing the server to crash.

This PR allows `err.meta` to be set (is returned as `meta` in the response, like before), but also `err.meta.headers` are copied to the actual error response headers.

Of course caution is required when using headers like `content-type`, but when specifically adding headers to the Error object, it is to be assumed that this is intentional.