### PR TITLE
fix: make config-loader fs operations async (fixes #23)

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('node:fs/promises');
 const path = require('path');
 
 /**
@@ -12,16 +12,16 @@ const path = require('path');
  * @return {Array}
  * @private
  */
-function walk(configDirectory, resourceName, resources) {
+async function walk(configDirectory, resourceName, resources) {
     resourceName = resourceName || '';
     resources = resources || {};
 
-    fs.readdirSync(path.join(configDirectory, resourceName)).forEach((fileName) => {
+    for (const fileName of await fs.readdir(path.join(configDirectory, resourceName))) {
         const subResourceName = (resourceName !== '' ? resourceName + '/' : '') + fileName;
         const absoluteFilePath = path.join(configDirectory, subResourceName);
-        const stat = fs.statSync(absoluteFilePath);
+        const stat = await fs.stat(absoluteFilePath);
         if (stat && stat.isDirectory()) {
-            walk(configDirectory, subResourceName, resources);
+            await walk(configDirectory, subResourceName, resources);
         } else if (resourceName !== '') {
             if (fileName.startsWith('config.')) {
                 if (!resources[resourceName]) resources[resourceName] = {};
@@ -32,7 +32,7 @@ function walk(configDirectory, resourceName, resources) {
                 resources[resourceName].instanceFile = absoluteFilePath;
             }
         }
-    });
+    }
 
     return resources;
 }
@@ -58,12 +58,17 @@ module.exports = async function configLoader(api, options) {
     const configDirectory = path.resolve(cfg.directory);
     const configParsers = cfg.parsers;
 
-    if (!fs.existsSync(configDirectory)) {
+    if (
+        !(await fs
+            .access(configDirectory)
+            .then(() => true)
+            .catch(() => false))
+    ) {
         throw new Error(`Config directory "${configDirectory}" does not exist`);
     }
 
     try {
-        resources = walk(configDirectory);
+        resources = await walk(configDirectory);
     } catch (err) {
         err.message = 'Error reading resource directory tree: ' + err.message;
         throw err;

--- a/test/config-loader.spec.js
+++ b/test/config-loader.spec.js
@@ -33,7 +33,7 @@ describe('config-loader', () => {
         });
     });
 
-    xit('should read configs from directories', (done) => {
+    it('should read configs from directories', (done) => {
         fsMock({
             config: {
                 resource1: { 'config.xml': '' },
@@ -56,7 +56,7 @@ describe('config-loader', () => {
             .catch(done);
     });
 
-    xit('should read configs recursively', (done) => {
+    it('should read configs recursively', (done) => {
         fsMock({
             config: {
                 groupfolder1: {
@@ -90,7 +90,7 @@ describe('config-loader', () => {
             .catch(done);
     });
 
-    xit('should strip path to config directory from resource', (done) => {
+    it('should strip path to config directory from resource', (done) => {
         fsMock({
             configs: {
                 are: {
@@ -126,7 +126,7 @@ describe('config-loader', () => {
             .catch(done);
     });
 
-    xit('should strip path also for relative paths', (done) => {
+    it('should strip path also for relative paths', (done) => {
         fsMock({
             configs: {
                 'relative-path': {
@@ -150,7 +150,7 @@ describe('config-loader', () => {
             .catch(done);
     });
 
-    xit('should issue an error if no parser is found for a file extension extension', (done) => {
+    it('should issue an error if no parser is found for a file extension extension', (done) => {
         fsMock({
             config: {
                 resource1: { 'config.xml': '' },
@@ -169,7 +169,7 @@ describe('config-loader', () => {
         });
     });
 
-    xit('should register additional loaders', (done) => {
+    it('should register additional loaders', (done) => {
         fsMock({
             config: {
                 resource1: { 'config.xml': '' },
@@ -195,7 +195,7 @@ describe('config-loader', () => {
             .catch(done);
     });
 
-    xit('should ignore all other but config files', (done) => {
+    it('should ignore all other but config files', (done) => {
         fsMock({
             config: {
                 groupfolder1: {


### PR DESCRIPTION
Since config-loader is async anyway, we can use the promise versions of `fs` methods. This has the nice side-effect of fixing the `mock-fs` tests (#23).